### PR TITLE
custom docker image with weaviate-client 3.26.7

### DIFF
--- a/langflow/0.1.1/values.yaml
+++ b/langflow/0.1.1/values.yaml
@@ -74,9 +74,9 @@ langflow:
     backendOnly: true
     numWorkers: 1
     image:
-      repository: langflowai/langflow
+      repository: mendeza/langflow
       imagePullPolicy: IfNotPresent
-      tag: latest
+      tag: 1.0.4
     command:
       - python
       - -m


### PR DESCRIPTION
There is currently an issue with creating a langflow pipeline that connects to weaviate in PCAI. This PR implements a workaround to overcome this issue.

I am not sure if this should be merged, becuase updating weaviate helm chart (to use tagged image 1.30.0 instead of 1.28.4) may resolve the issue.

# Overview of issue:
Langflow helm chart (in this repo)  uses docker image langflowai/langflow:latest. This docker image uses python package weaviate-client 4.10. This version seems to be not compatible with the current version of weaviate helm chart that deploys on PCAI. 

# Notes on issue
The weaviate helm chart (in ai-solution-eng framework repo) is using tagged version [1.28.4](https://github.com/ai-solution-eng/frameworks/blob/b04fd38abbfcc518a4815cb6f1277024d8619c01/weaviate/17.4.2/values.yaml#L10). This is behind the latest version 1.30.0.

This may be the culprit of the issue. 1.28.4 may expect python weaviate-client to be <4.0.0

# Workaround
According to this open langflow issue: https://github.com/langflow-ai/langflow/issues/6007 

What will resolve this issue is in the container, running: uv pip install weaviate-client==3.26.7

so I built a container `mendeza/langflow:1.0.4` that implements this change. 

Here is how I built the container mendeza/langflow:1.0.4

`docker run --platform linux/amd64 -it --entrypoint /bin/bash langflowai/langflow`

`uv pip install weaviate-client==3.26.7`

`docker commit --change='CMD ["langflow", "run"]' 2f8549ab10d1 mendeza/langflow:1.0.4`

`docker push mendeza/langflow:1.0.4`