### PR TITLE
add self-signed certificate injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/langflow/0.1.1/Chart.yaml
+++ b/langflow/0.1.1/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
     email: contact@langflow.org
 name: langflow-ide
 type: application
-version: 0.1.1
+version: 0.1.1-pcai

--- a/langflow/0.1.1/templates/backend-statefulset.yaml
+++ b/langflow/0.1.1/templates/backend-statefulset.yaml
@@ -47,6 +47,14 @@ spec:
         {{- with .Values.langflow.backend.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if .Values.ezua.selfsignedcert.enabled }}
+        - name: ingress-ca
+          secret:
+            secretName: ingress-cert
+            items:
+              - key: ca.crt
+                path: ingress-ca.crt
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -82,6 +90,11 @@ spec:
             {{- with .Values.langflow.backend.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if .Values.ezua.selfsignedcert.enabled }}
+            - name: ingress-ca
+              mountPath: /etc/ssl/custom-ca
+              readOnly: true
+            {{- end }}
           {{- end }}
           livenessProbe:
             httpGet:
@@ -108,6 +121,14 @@ spec:
             {{- if .Values.langflow.backend.sqlite.enabled }}
             - name: LANGFLOW_DATABASE_URL
               value: "sqlite:////data/langflow.db"
+            {{- end }}
+            {{- if .Values.ezua.selfsignedcert.enabled }}
+            - name: REQUESTS_CA_BUNDLE
+              value: /etc/ssl/custom-ca/ingress-ca.crt
+            - name: SSL_CERT_FILE
+              value: /etc/ssl/custom-ca/ingress-ca.crt
+            - name: CURL_CA_BUNDLE
+              value: /etc/ssl/custom-ca/ingress-ca.crt
             {{- end }}
             {{- with .Values.langflow.backend.env }}
             {{- toYaml . | nindent 12 }}

--- a/langflow/0.1.1/values.yaml
+++ b/langflow/0.1.1/values.yaml
@@ -19,7 +19,8 @@ serviceAccount:
 
 ingress:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -46,7 +47,6 @@ podSecurityContext:
   runAsNonRoot: true
   runAsGroup: 1000
 
-
 langflow:
   global:
     image:
@@ -59,7 +59,7 @@ langflow:
     backendOnly: true
     numWorkers: 1
     image:
-#      repository: langflowai/langflow
+      #      repository: langflowai/langflow
       repository: acarboni/langflow-ide
       imagePullPolicy: IfNotPresent
       tag: 1.4.2
@@ -90,6 +90,7 @@ langflow:
         value: "/app/db/alembic.log"
       - name: LANGFLOW_UPDATE_STARTER_PROJECTS
         value: "false"
+
     nodeSelector: {}
     tolerations: []
     affinity: {}
@@ -238,7 +239,7 @@ langflow:
       - name: tmp
         mountPath: /tmp
         readOnly: false
-  
+
   podAnnotations:
     sidecar.istio.io/inject: "false"
 
@@ -266,3 +267,5 @@ ezua:
     providerName: "oauth2-proxy"
     matchLabels:
       app: "langflow-service"
+  selfsignedcert:
+    enabled: true

--- a/langflow/porting.md
+++ b/langflow/porting.md
@@ -16,6 +16,21 @@ appVersion: 1.4.2
 
 because we are targeting a specific version. Also, the patched image refers to LangFlow v1.4.2.
 
+Changed:
+
+```
+version: 0.1.1
+```
+
+to 
+
+```
+version: 0.1.1-pcai
+```
+
+to indicate that this chart is configured for deployment in HPE Private Cloud AI environment.
+
+
 ## values.yaml
 
 Changed the container image from **langflowai/langflow** to a custom one. There is no easy way to patch LangFlow without a custom image as the file system where **uv** is located is read-olny:
@@ -43,7 +58,7 @@ The langflow.backend section has been changed to include CPU limits and to incre
       initialDelaySeconds: 30
 ```
 
-PostgreSQL has been configured as an external database, changing this one:
+PostgreSQL has been configured as an external database, so changing this one:
 ```
     externalDatabase:
       enabled: false
@@ -70,7 +85,7 @@ to this one:
             name: "langflow-ide-postgresql-service"
 ```
 
-At the end of the file, we also enabled the embedded PostgreSQL database, as we want to use the one provided by LangFlw itself:
+At the end of the file, we also enabled the embedded PostgreSQL database, as we want to use the one provided by LangFlow itself:
 ```
 postgresql:
   enabled: true
@@ -81,7 +96,7 @@ postgresql:
     database: "langflow-db"
 ```
 
-and, of course, the internal SqlLite DB has been disabled:
+And, of course, the internal SqlLite DB has been disabled:
 ```
     sqlite:
       enabled: false
@@ -119,6 +134,66 @@ ezua:
       app: "langflow-service"
 ```
 
+If the cluster is using self-signed certificate, we let the user to adopt this and require them to copy the secret containing the `ca.crt` to the namespace that this chart will be installed. Use this command to copy the secret from `istio-system` to the 'new namespace' (this must match the namespace given in Import Framework wizard, code provided below assumes chart will be installed to `langflow` namespace):
+
+```bash
+RELEASE_NAMESPACE=langflow
+kubectl create ns ${RELEASE_NAMESPACE}
+kubectl get secret ingress-cert \
+  --namespace=istio-system \
+  -o yaml | \
+  grep -v "namespace: istio-system" | \
+  kubectl apply --namespace=${RELEASE_NAMESPACE} -f -
+```
+  <!-- sed "s/namespace: istio-system/namespace: ${RELEASE_NAMESPACE}/" | \ -->
+
+Finally, we've added following to the `ezua` section to indicate self-signed certificate is used by the cluster. Change this to `false` if no need for self-signed certificate injection.
+
+```yaml
+ezua:
+  selfsignedcert:
+    enabled: true
+```
+
+## backend-statefulset.yaml
+
+Following changes are mode to the StatefulSet to enable copied secret for Self-signed Certificate to be used if required. This will let this app to access endpoints deployed within the platform using their public URLs.
+
+At line 50, following code is added to attach the copied secret as a volume:
+
+```yaml
+        {{- if .Values.ezua.selfsignedcert.enabled }}
+        - name: ingress-ca
+        secret:
+          secretName: ingress-cert
+          items:
+            - key: ca.crt
+              path: ingress-ca.crt
+        {{- end }}
+```
+
+At line 93, following code is added to mount the secret into `/etc/ssl/custom-ca` folder:
+
+```yaml
+            {{- if .Values.ezua.selfsignedcert.enabled }}
+            - name: ingress-ca
+              mountPath: /etc/ssl/custom-ca
+              readOnly: true
+            {{- end }}
+```
+
+At line 125, following environment variables are added to allow various libraries (ie, `libcurl` and python `requests`) to use the injected certificate:
+
+```yaml
+            {{- if .Values.ezua.selfsignedcert.enabled }}
+            - name: REQUESTS_CA_BUNDLE
+              value: /etc/ssl/custom-ca/ingress-ca.crt
+            - name: SSL_CERT_FILE
+              value: /etc/ssl/custom-ca/ingress-ca.crt
+            - name: CURL_CA_BUNDLE
+              value: /etc/ssl/custom-ca/ingress-ca.crt
+            {{- end }}
+```
 
 ## New files
 
@@ -133,6 +208,5 @@ The following new files has been added to complete the configuration:
 
 Chart has been downloaded from [here](https://github.com/langflow-ai/langflow-helm-charts/releases/download/langflow-runtime-0.1.1/langflow-runtime-0.1.1.tgz).
 
-The documentation on how to configure LangFlow with PostgreSQL is [here]
-(https://github.com/langflow-ai/langflow-helm-charts/blob/main/examples/langflow-ide/dev-values-postgres.yaml)
+The documentation on how to configure LangFlow with PostgreSQL is [here](https://github.com/langflow-ai/langflow-helm-charts/blob/main/examples/langflow-ide/dev-values-postgres.yaml)
 


### PR DESCRIPTION
Enabling user to inject self-signed certificate from the copied secret. Secret `ingress-cert` in istio-system has ca.crt that can be used for trusted root certificate and this can be mounted into the backend pod once copied by the user into the namespace that this chart is installed. Libraries will be notified by the environment variables to point to the mounted  CA  certificate.