### PR TITLE
GCP Traffic Extension: Use FullDuplexStreamed for request bodySendMode

### DIFF
--- a/nemo-microservices/25.12.0/charts/nemo-guardrails/templates/gcptrafficextension.yaml
+++ b/nemo-microservices/25.12.0/charts/nemo-guardrails/templates/gcptrafficextension.yaml
@@ -33,6 +33,6 @@ spec:
             - ResponseHeaders
             - ResponseBody
             - ResponseTrailers
-          requestBodySendMode: Streamed
+          requestBodySendMode: FullDuplexStreamed
           responseBodySendMode: FullDuplexStreamed
 {{- end }}


### PR DESCRIPTION
When processing ext_proc calls from GCP data planes, both request and response body send modes should use full duplex streamed. Otherwise, on the request path, long prompts that cross multiple stream chunks will not be sanitizable. To properly sanitize these prompts, the ext_proc server needs to buffer the entire body, sanitize it and then stream the sanitized request back to the data plane. This is how other GCP internal services doing prompt sanitization work.
